### PR TITLE
Add "info" to resolver function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export const baseResolver = createResolver(
     Only mask outgoing errors that aren't already apollo-errors, 
     such as ORM errors etc
   */
-  (root, args, context, error) => isInstance(error) ? error : new UnknownError()
+  (root, args, context, info, error) => isInstance(error) ? error : new UnknownError()
 );
 ```
 
@@ -125,7 +125,7 @@ const ExposedError = createError('ExposedError', {
 
 const banUser = isAdminResolver.createResolver(
   (root, { input }, { models: { UserModel } }) => UserModel.ban(input),
-  (root, args, context, error) => {
+  (root, args, context, info, error) => {
     /*
       For admin users, let's tell the user what actually broke
       in the case of an unhandled exception

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -4,14 +4,14 @@ import { isFunction, Promisify, isNotNullOrUndefined } from './util';
 
 export const createResolver = (resFn, errFn) => {
   const Promise = getPromise();
-  const baseResolver = (root, args = {}, context = {}) => {
+  const baseResolver = (root, args = {}, context = {}, info = {}) => {
     // Return resolving promise with `null` if the resolver function param is not a function
     if (!isFunction(resFn)) return Promise.resolve(null);
-    return Promisify(resFn)(root, args, context).catch(e => {
+    return Promisify(resFn)(root, args, context, info).catch(e => {
       // On error, check if there is an error handler.  If not, throw the original error
       if (!isFunction(errFn)) throw e;
       // Call the error handler.
-      return Promisify(errFn)(root, args, context, e).then(parsedError => {
+      return Promisify(errFn)(root, args, context, info, e).then(parsedError => {
         // If it resolves, throw the resolving value or the original error.
         throw parsedError || e
       }, parsedError => {
@@ -24,26 +24,26 @@ export const createResolver = (resFn, errFn) => {
   baseResolver.createResolver = (cResFn, cErrFn) => {
     const Promise = getPromise();
 
-    const childResFn = (root, args, context) => {
+    const childResFn = (root, args, context, info) => {
       // Start with either the parent resolver function or a no-op (returns null)
-      const entry = isFunction(resFn) ? Promisify(resFn)(root, args, context) : Promise.resolve(null);
+      const entry = isFunction(resFn) ? Promisify(resFn)(root, args, context, info) : Promise.resolve(null);
       return entry.then(r => {
         // If the parent returns a value, continue
         if (isNotNullOrUndefined(r)) return r;
         // Call the child resolver function or a no-op (returns null)
-        return isFunction(cResFn) ? Promisify(cResFn)(root, args, context) : Promise.resolve(null);
+        return isFunction(cResFn) ? Promisify(cResFn)(root, args, context, info) : Promise.resolve(null);
       });
     };
 
-    const childErrFn = (root, args, context, err) => {
+    const childErrFn = (root, args, context, info, err) => {
       // Start with either the child error handler or a no-op (returns null)
-      const entry = isFunction(cErrFn) ? Promisify(cErrFn)(root, args, context, err) : Promise.resolve(null);
+      const entry = isFunction(cErrFn) ? Promisify(cErrFn)(root, args, context, info, err) : Promise.resolve(null);
       
       return entry.then(r => {
         // If the child returns a value, throw it
         if (isNotNullOrUndefined(r)) throw r;
         // Call the parent error handler or a no-op (returns null)
-        return isFunction(errFn) ? Promisify(errFn)(root, args, context, err).then(e => {
+        return isFunction(errFn) ? Promisify(errFn)(root, args, context, info, err).then(e => {
           // If it resolves, throw the resolving value or the original error
           throw e || err;
         }, e => {

--- a/test/unit/resolver_spec.js
+++ b/test/unit/resolver_spec.js
@@ -34,7 +34,7 @@ describe('(unit) src/resolver.js', () => {
         stub(r3, 'handle', r3.handle);
 
         const resolver = createResolver(r1.handle, r1.error).createResolver(r2.handle, r2.error).createResolver(r3.handle, r3.error).createResolver(
-          (root, args, context) => {
+          (root, args, context, info) => {
             throw new Error('first error');
           }
         );
@@ -50,6 +50,25 @@ describe('(unit) src/resolver.js', () => {
           })
           .catch(e => next(e))
       });
+    });
+    describe('all resolver parameters passed', () => {
+      it('passes all parameters', (next) => {
+        const resolver = createResolver(
+          (root, args, context, info) => {
+            return { root, args, context, info }
+          }
+        );
+        
+        resolver('root', 'args', 'context', 'info')
+          .then(({root, args, context, info}) => {
+            expect(root).to.equal('root');
+            expect(args).to.equal('args');
+            expect(context).to.equal('context');
+            expect(info).to.equal('info')
+            next();
+          })
+          .catch(e => next(e));
+      })
     });
     describe('error handling', () => {
       context('when error callback exists', () => {


### PR DESCRIPTION
This turned out to be a pretty simple addition. The existing tests passed, not sure if something new should be added. I did not commit the changes to dist, figured that's part of your CI process.

I updated the README to reflect the new function signatures.

In the changelog, the breaking change to be noted is that resolvers which receive the error argument will need to add the `info` arg in between `context` and `errors`:

```
resolver(root, args, context, info, errors) {}
```

In practice, this will probably only apply to `baseResolver` and perhaps a few outliers.

Anything I'm missing?

Ref. #3 