### PR TITLE
Added the missing "info" argument to the GraphQL resolver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export const baseResolver = createResolver(
     Only mask outgoing errors that aren't already apollo-errors,
     such as ORM errors etc
   */
-  (root, args, context, error) => isInstance(error) ? error : new UnknownError()
+  (root, args, context, info, error) => isInstance(error) ? error : new UnknownError()
 );
 ```
 
@@ -129,7 +129,7 @@ const ExposedError = createError('ExposedError', {
 
 const banUser = isAdminResolver.createResolver(
   (root, { input }, { models: { UserModel } }) => UserModel.ban(input),
-  (root, args, context, error) => {
+  (root, args, context, info, error) => {
     /*
       For admin users, let's tell the user what actually broke
       in the case of an unhandled exception

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -4,14 +4,14 @@ import { isFunction, Promisify, isNotNullOrUndefined } from './util';
 
 export const createResolver = (resFn, errFn) => {
   const Promise = getPromise();
-  const baseResolver = (root, args = {}, context = {}) => {
+  const baseResolver = (root, args = {}, context = {}, info = {}) => {
     // Return resolving promise with `null` if the resolver function param is not a function
     if (!isFunction(resFn)) return Promise.resolve(null);
-    return Promisify(resFn)(root, args, context).catch(e => {
+    return Promisify(resFn)(root, args, context, info).catch(e => {
       // On error, check if there is an error handler.  If not, throw the original error
       if (!isFunction(errFn)) throw e;
       // Call the error handler.
-      return Promisify(errFn)(root, args, context, e).then(parsedError => {
+      return Promisify(errFn)(root, args, context, info, e).then(parsedError => {
         // If it resolves, throw the resolving value or the original error.
         throw parsedError || e
       }, parsedError => {
@@ -23,26 +23,26 @@ export const createResolver = (resFn, errFn) => {
   baseResolver['createResolver'] = (cResFn, cErrFn) => {
     const Promise = getPromise();
 
-    const childResFn = (root, args, context) => {
+    const childResFn = (root, args, context, info) => {
       // Start with either the parent resolver function or a no-op (returns null)
-      const entry = isFunction(resFn) ? Promisify(resFn)(root, args, context) : Promise.resolve(null);
+      const entry = isFunction(resFn) ? Promisify(resFn)(root, args, context, info) : Promise.resolve(null);
       return entry.then(r => {
         // If the parent returns a value, continue
         if (isNotNullOrUndefined(r)) return r;
         // Call the child resolver function or a no-op (returns null)
-        return isFunction(cResFn) ? Promisify(cResFn)(root, args, context) : Promise.resolve(null);
+        return isFunction(cResFn) ? Promisify(cResFn)(root, args, context, info) : Promise.resolve(null);
       });
     };
 
-    const childErrFn = (root, args, context, err) => {
+    const childErrFn = (root, args, context, info, err) => {
       // Start with either the child error handler or a no-op (returns null)
-      const entry = isFunction(cErrFn) ? Promisify(cErrFn)(root, args, context, err) : Promise.resolve(null);
+      const entry = isFunction(cErrFn) ? Promisify(cErrFn)(root, args, context, info, err) : Promise.resolve(null);
 
       return entry.then(r => {
         // If the child returns a value, throw it
         if (isNotNullOrUndefined(r)) throw r;
         // Call the parent error handler or a no-op (returns null)
-        return isFunction(errFn) ? Promisify(errFn)(root, args, context, err).then(e => {
+        return isFunction(errFn) ? Promisify(errFn)(root, args, context, info, err).then(e => {
           // If it resolves, throw the resolving value or the original error
           throw e || err;
         }, e => {

--- a/test/unit/resolver_spec.js
+++ b/test/unit/resolver_spec.js
@@ -34,7 +34,7 @@ describe('(unit) dist/resolver.js', () => {
         stub(r3, 'handle', r3.handle);
 
         const resolver = createResolver(r1.handle, r1.error).createResolver(r2.handle, r2.error).createResolver(r3.handle, r3.error).createResolver(
-          (root, args, context) => {
+          (root, args, context, info) => {
             throw new Error('first error');
           }
         );


### PR DESCRIPTION
Hey!

I noticed that there was a PR made for this a while ago but there was no movement. 
Currently I am using my own hacked fix, so I figured it would be good to get this PR made and pushed into the main repo.

This does contain breaking changes however. Essentially, the error argument is now the 5th argument, instead of the 4th. So anyone currently this repo will have to update.

Let me know what I can do to help get this merged.

- [x] Tests updated
- [x] Docs updated

Thanks