### PR TITLE
4th option param should be passed to chained resolvers

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -30,7 +30,7 @@ export const createResolver = (resFn, errFn) => {
         // If the parent returns a value, continue
         if (isNotNullOrUndefined(r)) return r;
         // Call the child resolver function or a no-op (returns null)
-        return isFunction(cResFn) ? Promisify(cResFn)(root, args, context) : Promise.resolve(null);
+        return isFunction(cResFn) ? Promisify(cResFn)(root, args, context, info) : Promise.resolve(null);
       });
     };
 


### PR DESCRIPTION
The 4th option param was not passed to child resolvers, thus it was available only in base (or first) resolver which seems to be not an intended behavior. This PR fixes this issue.