### PR TITLE
Upgrade to CircleCI 2.0 config file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,43 @@
-machine:
-  node:
-    version: 5.5.0
-
-dependencies:
-  override:
-    - make configure
-
-test:
-  override:
-    - make lint
-    - make
-    - make test
+version: 2
+jobs:
+  build:
+    working_directory: ~/apollo-resolvers
+    parallelism: 1
+    shell: /bin/bash --login
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    steps:
+    - checkout
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    - run:
+        working_directory: ~/apollo-resolvers
+        command: nvm install 5.5.0 && nvm alias default 5.5.0
+    # Dependencies
+    # Restore the dependency cache
+    - restore_cache:
+        keys:
+        - v1-dep-{{ .Branch }}-
+        - v1-dep-master-
+        - v1-dep-
+    - run: make configure
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        - ./node_modules
+    - run: make lint
+    - run: make
+    - run: make test
+    # Teardown
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results


### PR DESCRIPTION
Circle CI's will discontinue support of v 1.0 configs as of 31/08/2018.

This commit adds a Auto-gen 2.0 config using CircleCIs upgrade script. I've also cleaned up that config to remove unhelpful comments, correct paths and remove references to unused dependency dirs.