### PR TITLE
add scripts defined in Makefile to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "make test"
+    "test": "mocha",
+    "build": "tsc",
+    "lint": "eslint src test",
+    "clean": "rimraf test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey there! I was just wondering why this project uses a `Makefile` over `package.json scripts`.

AFAIK using Makefile will be another obstacle that new contributors that do not have a unix based system, have to overcome.