### PR TITLE
chore: add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "extends": ["config:base"],
+  "depTypes": [
+    {
+      "depType": "dependencies",
+      "pinVersions": false
+    },
+    {
+      "depTypes": "peerDependencies",
+      "pinVersions": false
+    }
+  ],
+  "semanticCommits": true,
+  "timezone": "America/Los_Angeles",
+  "schedule": [
+    "after 10pm and before 5am on every weekday"
+  ],
+  "rebaseStalePrs": true,
+  "prCreation": "not-pending",
+  "automerge": "minor",
+  "labels": [
+    "dependencies"
+  ],
+  "assignees": [
+    "@thebigredgeek",
+    "@mringer"
+  ],
+  "reviewers": [
+    "@thebigredgeek",
+    "@mringer"
+  ]
+}


### PR DESCRIPTION
**INFO: TESTS WILL FAIL UNTIL #43 IS MERGED**

Why? https://github.com/renovatebot/renovate#why-use-renovate

TL;DR: renovate automatically creates and merges pull requests for updating the dependencies declared in the `package.json` (if the tests pass).

What to do:

After merging this pull request you should add the renovate integration to this repository. 

This can be done here: https://github.com/marketplace/renovate/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45NTk=#pricing-and-setup